### PR TITLE
expand/contract OverviewColumn

### DIFF
--- a/src/components/governance/OverviewColumn.tsx
+++ b/src/components/governance/OverviewColumn.tsx
@@ -8,7 +8,7 @@ import { TYPE } from "../../theme";
 import { TabOption } from "../governance/Tabs";
 import { Link, useLocation } from "react-router-dom";
 
-export const OVERVIEW_EXPANSION_WIDTH = 100;
+export const OVERVIEW_EXPANSION_WIDTH = 99;
 
 const Wrapper = styled.div<{ backgroundColor?: string; expanded?: boolean }>`
   margin-left: 70px;
@@ -68,7 +68,12 @@ export default function OverviewColumn({
           <ChevronLeft />
         </IconButton>
       </ButtonContainer>
-      <AutoColumn gap="md">
+      <AutoColumn
+        gap="md"
+        style={{
+          opacity: expanded ? 1 : 0,
+        }}
+      >
         <TYPE.main
           fontSize="24px"
           fontWeight="700"

--- a/src/components/governance/OverviewColumn.tsx
+++ b/src/components/governance/OverviewColumn.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { ButtonCustom } from "../Button";
+import { ChevronLeft } from "react-feather";
 import styled from "styled-components";
 import { useActiveProtocol } from "../../state/governance/hooks";
 import { AutoColumn } from "../Column";
@@ -6,22 +8,66 @@ import { TYPE } from "../../theme";
 import { TabOption } from "../governance/Tabs";
 import { Link, useLocation } from "react-router-dom";
 
-const Wrapper = styled.div<{ backgroundColor?: string }>`
+export const OVERVIEW_EXPANSION_WIDTH = 100;
+
+const Wrapper = styled.div<{ backgroundColor?: string; expanded?: boolean }>`
   margin-left: 70px;
   padding: 2rem;
   border-right: 1px solid ${({ backgroundColor }) => backgroundColor};
+  transform: translateX(-${OVERVIEW_EXPANSION_WIDTH}px);
+  transition: transform 0.2s;
 
   ${({ theme }) => theme.mediaWidth.upToLarge`
     display: none;
   `};
+
+  ${({ expanded }) =>
+    expanded &&
+    `
+    transform: translateX(0px);
+  `};
 `;
 
-export default function OverviewColumn() {
+const ButtonContainer = styled.div<{ expanded?: boolean }>`
+  display: flex;
+  justify-content: flex-end;
+  transform: translateX(25px);
+
+  ${({ expanded }) =>
+    expanded &&
+    `
+    transform: translateX(10px);
+  `};
+`;
+
+const IconButton = styled(ButtonCustom)`
+  padding: 0;
+  background: none;
+  cursor: pointer;
+  color: black;
+  width: auto;
+`;
+
+export default function OverviewColumn({
+  expanded,
+  onToggleExpand,
+}: {
+  expanded: boolean;
+  onToggleExpand: () => void;
+}) {
   const [activeProtocol] = useActiveProtocol();
   const location = useLocation();
 
   return (
-    <Wrapper backgroundColor={activeProtocol?.secondaryColor}>
+    <Wrapper
+      backgroundColor={activeProtocol?.secondaryColor}
+      expanded={expanded}
+    >
+      <ButtonContainer expanded={expanded}>
+        <IconButton bgColor="white" onClick={onToggleExpand}>
+          <ChevronLeft />
+        </IconButton>
+      </ButtonContainer>
       <AutoColumn gap="md">
         <TYPE.main
           fontSize="24px"

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -19,7 +19,9 @@ import DelegateInfo from "./DelegateInfo";
 import DelegateModal from "../components/vote/DelegateModal";
 import { useModalOpen, useToggleModal } from "../state/application/hooks";
 import { ApplicationModal } from "../state/application/actions";
-import OverviewColumn from "../components/governance/OverviewColumn";
+import OverviewColumn, {
+  OVERVIEW_EXPANSION_WIDTH,
+} from "../components/governance/OverviewColumn";
 import { useLocation } from "react-router-dom";
 import { identityOnlyPath } from "../state/governance/reducer";
 import Amplifi from "./Amplifi";
@@ -27,15 +29,23 @@ import CampaignDetails from "components/campaigns/CampaignDetails";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
-const SiteWrapper = styled.div`
+const FIRST_2_COLS_WIDTH = 320;
+
+const SiteWrapper = styled.div<{ expandedOverview?: boolean }>`
   height: 100vh;
   width: 100%;
   display: grid;
-  grid-template-columns: 320px 1fr 376px;
+  grid-template-columns: ${FIRST_2_COLS_WIDTH - OVERVIEW_EXPANSION_WIDTH}px 1fr 376px;
   overflow: auto;
 
   ${({ theme }) => theme.mediaWidth.upToLarge`
     grid-template-columns: 1fr 376px;
+  `};
+
+  ${({ expandedOverview }) =>
+    expandedOverview &&
+    `
+  grid-template-columns: ${FIRST_2_COLS_WIDTH}px 1fr 376px;
   `};
 
   @media (max-width: 1080px) {
@@ -72,6 +82,7 @@ function TopLevelModals() {
 
 export default function App() {
   const identityOnlyFlow = identityOnlyPath(useLocation().pathname);
+  const [expandedOverview, setExpandedOverview] = React.useState(true);
 
   return (
     <Suspense fallback={null}>
@@ -79,9 +90,12 @@ export default function App() {
       <Route component={DarkModeQueryParamReader} />
       <Route component={TwitterAccountQueryParamReader} />
       {!identityOnlyFlow && (
-        <SiteWrapper>
+        <SiteWrapper expandedOverview={expandedOverview}>
           <SideMenu />
-          <OverviewColumn />
+          <OverviewColumn
+            expanded={expandedOverview}
+            onToggleExpand={() => setExpandedOverview(!expandedOverview)}
+          />
           <ContentWrapper>
             <Web3Status />
             <Popups />


### PR DESCRIPTION
this adds the ability to expand and contract the overview column:

https://user-images.githubusercontent.com/109034246/179453591-42311381-cf78-4cc6-9348-21d5beccf98b.mov

the setting is controlled by a `expandedOverview` component state

i also added some new constants to make it easy to play around with different sizes, to see what feels good
